### PR TITLE
[PO-10] Add Transactions generator

### DIFF
--- a/src/main/scala/io/iohk/praos/domain/GenesisBlock.scala
+++ b/src/main/scala/io/iohk/praos/domain/GenesisBlock.scala
@@ -10,6 +10,12 @@ import io.iohk.praos.crypto.{Seed, combineSeeds}
   * @param genesisNonce  The nonce to be used.
   */
 case class GenesisBlock(genesisDistribution: StakeDistribution, genesisNonce: Seed) {
+
+  /**
+    * @note The application of a block to a genesis block is *not* a genesis block when the applied block is not the
+    *       last block in an epoch, at least at the conceptual level. However, for the sake of simplicity,
+    *       GenesisBlocks are also used to store intermediate results when several blocks are applied in sequence.
+    */
   def applyBlock(block: Block): GenesisBlock = {
     val newGenesisDistribution = block.data.foldLeft(genesisDistribution)(
       (sd: StakeDistribution, tx: Transaction) => applyTransaction(tx, sd)

--- a/src/main/scala/io/iohk/praos/util/TransactionsGenerator.scala
+++ b/src/main/scala/io/iohk/praos/util/TransactionsGenerator.scala
@@ -34,11 +34,12 @@ object TransactionsGenerator {
   }
 
   def generateTxs(stakeDistribution: StakeDistribution, n: Int): List[Transaction] = {
+    require(n > 0, "Number of transactions must be positive")
     @tailrec
     def rec(stakeDistribution: StakeDistribution, n: Int, acc: List[Transaction]): List[Transaction] = {
-      val transaction = generateTx(stakeDistribution)
       if (n == 0) acc
       else {
+        val transaction = generateTx(stakeDistribution)
         val newStakeDistribution = applyTransaction(transaction, stakeDistribution)
         rec(newStakeDistribution, n - 1, transaction :: acc)
       }

--- a/src/main/scala/io/iohk/praos/util/TransactionsGenerator.scala
+++ b/src/main/scala/io/iohk/praos/util/TransactionsGenerator.scala
@@ -7,7 +7,7 @@ import io.iohk.praos.domain.{Stake, StakeDistribution, Transaction, applyTransac
 
 object TransactionsGenerator {
 
-  type Stakeholder = (Key, Stake)
+  private type Stakeholder = (Key, Stake)
 
   private def chooseRandomStakeholderFrom(stakeDistribution: StakeDistribution): Stakeholder = {
     val stakeDistributionAsSeq = stakeDistribution.toSeq
@@ -34,7 +34,7 @@ object TransactionsGenerator {
   }
 
   def generateTxs(stakeDistribution: StakeDistribution, n: Int): List[Transaction] = {
-    require(n > 0, "Number of transactions must be positive")
+    require(n >= 0, "Number of transactions must be greater or equal to zero")
     @tailrec
     def rec(stakeDistribution: StakeDistribution, n: Int, acc: List[Transaction]): List[Transaction] = {
       if (n == 0) acc

--- a/src/test/scala/io/iohk/praos/util/TransactionGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/praos/util/TransactionGeneratorSpec.scala
@@ -29,7 +29,6 @@ class TransactionGeneratorSpec  extends FlatSpec with Matchers {
 
   "TransactionGeneratorSpec" should "generate 5 consecutive transactions given a stakeholder distribution" in new TestSetup {
     val txs: List[Transaction] = TransactionsGenerator.generateTxs(initialStakeDistribution, 5)
-    txs.foreach(tx => println(tx.senderPublicKey, tx.stake ,tx.recipientPublicKey))
     txs.foldLeft(initialStakeDistribution) { (currentStakeDistribution, tx) => {
       val newStakeDistribution = applyTransaction(tx, currentStakeDistribution)
       checkTxIntegrity(currentStakeDistribution, tx, newStakeDistribution) shouldBe true


### PR DESCRIPTION
The tests for the Transactions generator could fail if the random transaction has the same sender and receipt, this is because of an error in the stake distribution implementation.