### PR TITLE
Fix/PO-19: Fix "self" transactions.

### DIFF
--- a/src/main/scala/io/iohk/praos/domain/package.scala
+++ b/src/main/scala/io/iohk/praos/domain/package.scala
@@ -25,10 +25,8 @@ package object domain {
       // TODO: Handle logic errors (i.e. that the transaction makes sense in the initial distribution)
       val resultingSenderStake = stakeDistribution(transaction.senderPublicKey) - transaction.stake
       val resultingRecipientStake = stakeDistribution(transaction.recipientPublicKey) + transaction.stake
-      val resultingStakeDistribution = stakeDistribution
-        .updated(transaction.senderPublicKey, resultingSenderStake)
-        .updated(transaction.recipientPublicKey, resultingRecipientStake)
-      resultingStakeDistribution
+      stakeDistribution + (transaction.senderPublicKey -> resultingSenderStake) +
+        (transaction.recipientPublicKey -> resultingRecipientStake)
     }
   }
 

--- a/src/main/scala/io/iohk/praos/domain/package.scala
+++ b/src/main/scala/io/iohk/praos/domain/package.scala
@@ -19,13 +19,17 @@ package object domain {
   def StakeDistribution(ps: (Key, Stake)*) = Map[Key, Stake](ps: _*)
 
   def applyTransaction(transaction: Transaction, stakeDistribution: StakeDistribution): StakeDistribution = {
-    // TODO: Handle logic errors (i.e. that the transaction makes sense in the initial distribution)
-    val resultingSenderStake = stakeDistribution(transaction.senderPublicKey) - transaction.stake
-    val resultingRecipientStake = stakeDistribution(transaction.recipientPublicKey) + transaction.stake
-    val resultingStakeDistribution = stakeDistribution
-      .updated(transaction.senderPublicKey, resultingSenderStake)
-      .updated(transaction.recipientPublicKey, resultingRecipientStake)
-    resultingStakeDistribution
+    if (transaction.senderPublicKey == transaction.recipientPublicKey) { // "self" transaction
+      stakeDistribution
+    } else {
+      // TODO: Handle logic errors (i.e. that the transaction makes sense in the initial distribution)
+      val resultingSenderStake = stakeDistribution(transaction.senderPublicKey) - transaction.stake
+      val resultingRecipientStake = stakeDistribution(transaction.recipientPublicKey) + transaction.stake
+      val resultingStakeDistribution = stakeDistribution
+        .updated(transaction.senderPublicKey, resultingSenderStake)
+        .updated(transaction.recipientPublicKey, resultingRecipientStake)
+      resultingStakeDistribution
+    }
   }
 
   /**

--- a/src/test/scala/io/iohk/praos/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/praos/domain/TransactionSpec.scala
@@ -25,34 +25,32 @@ class TransactionSpec extends FlatSpec with GivenWhenThen with Matchers {
     // A transaction transferring a stake of 3 from U1 to U2.
     val transaction1 = Transaction(publicKey1, publicKey2, 3)
 
-    // The resulting stake distribution of applying "transaction1" to "stakeDistribution".
-    val resultingStakeDistribution1 = applyTransaction(transaction1, stakeDistribution)
-
     // A transaction transferring a stake of 3 from U1 to U1 (a "self" transaction).
     val transaction2 = Transaction(publicKey1, publicKey1, 3)
-
-    // The resulting stake distribution of applying "transaction2" to "stakeDistribution".
-    val resultingStakeDistribution2 = applyTransaction(transaction2, stakeDistribution)
   }
 
 
 
   "The stakeholder U1 holding a stake of 10" should "have a resulting stake of 7" in new TestSetup {
     When("a transaction transferring a stake of 3 from U1 to U2 is applied")
-    resultingStakeDistribution1(publicKey1) shouldBe 7
+    val resultingStakeDistribution = applyTransaction(transaction1, stakeDistribution)
+    resultingStakeDistribution(publicKey1) shouldBe 7
   }
 
   "The stakeholder U2 holding a stake of 2" should "have a resulting stake of 5" in new TestSetup {
     When("a transaction transferring a stake of 3 from U1 to U2 is applied")
-    resultingStakeDistribution1(publicKey2) shouldBe 5
+    val resultingStakeDistribution = applyTransaction(transaction1, stakeDistribution)
+    resultingStakeDistribution(publicKey2) shouldBe 5
   }
 
   "A well-formed transaction" should "preserve the total stake across stake distributions" in new TestSetup {
-    val resultingStakeDistributionTotalStake = resultingStakeDistribution1.values.sum
+    val resultingStakeDistribution = applyTransaction(transaction1, stakeDistribution)
+    val resultingStakeDistributionTotalStake = resultingStakeDistribution.values.sum
     resultingStakeDistributionTotalStake shouldBe 20
   }
 
   "A \"self\" transaction" should "not modify a stake distributions" in new TestSetup {
-    resultingStakeDistribution2 shouldEqual stakeDistribution
+    val resultingStakeDistribution = applyTransaction(transaction2, stakeDistribution)
+    resultingStakeDistribution shouldEqual stakeDistribution
   }
 }

--- a/src/test/scala/io/iohk/praos/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/praos/domain/TransactionSpec.scala
@@ -9,36 +9,50 @@ import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
   */
 class TransactionSpec extends FlatSpec with GivenWhenThen with Matchers {
 
-  // Stakeholder U1
-  var publicKey1: Key = akka.util.ByteString("1")
+  trait TestSetup {
+    // Stakeholder U1
+    var publicKey1: Key = akka.util.ByteString("1")
 
-  // Stakeholder U2
-  val publicKey2: Key = akka.util.ByteString("2")
+    // Stakeholder U2
+    val publicKey2: Key = akka.util.ByteString("2")
 
-  // Stakeholder U3
-  val publicKey3: Key = akka.util.ByteString("3")
+    // Stakeholder U3
+    val publicKey3: Key = akka.util.ByteString("3")
 
-  // A stake distribution assigning 10 to U1, 2 to U2 and 8 to U3.
-  val stakeDistribution = StakeDistribution(publicKey1 -> 10, publicKey2 -> 2, publicKey3 -> 8)
+    // A stake distribution assigning 10 to U1, 2 to U2 and 8 to U3.
+    val stakeDistribution = StakeDistribution(publicKey1 -> 10, publicKey2 -> 2, publicKey3 -> 8)
 
-  // A transaction transferring a stake of 3 from U1 to U2.
-  val transaction = Transaction(publicKey1, publicKey2, 3)
+    // A transaction transferring a stake of 3 from U1 to U2.
+    val transaction1 = Transaction(publicKey1, publicKey2, 3)
 
-  // The resulting stake distribution of applying "transaction" to "stakeDistribution".
-  val resultingStakeDistribution = applyTransaction(transaction, stakeDistribution)
+    // The resulting stake distribution of applying "transaction1" to "stakeDistribution".
+    val resultingStakeDistribution1 = applyTransaction(transaction1, stakeDistribution)
 
-  "The stakeholder U1 holding a stake of 10" should "have a resulting stake of 7" in {
-    When("a transaction transferring a stake of 3 from U1 to U2 is applied")
-    resultingStakeDistribution(publicKey1) shouldBe 7
+    // A transaction transferring a stake of 3 from U1 to U1 (a "self" transaction).
+    val transaction2 = Transaction(publicKey1, publicKey1, 3)
+
+    // The resulting stake distribution of applying "transaction2" to "stakeDistribution".
+    val resultingStakeDistribution2 = applyTransaction(transaction2, stakeDistribution)
   }
 
-  "The stakeholder U2 holding a stake of 2" should "have a resulting stake of 5" in {
+
+
+  "The stakeholder U1 holding a stake of 10" should "have a resulting stake of 7" in new TestSetup {
     When("a transaction transferring a stake of 3 from U1 to U2 is applied")
-    resultingStakeDistribution(publicKey2) shouldBe 5
+    resultingStakeDistribution1(publicKey1) shouldBe 7
   }
 
-  "A well-formed transaction" should "preserve the total stake across stake distributions" in {
-    val resultingStakeDistributionTotalStake = resultingStakeDistribution.values.sum
+  "The stakeholder U2 holding a stake of 2" should "have a resulting stake of 5" in new TestSetup {
+    When("a transaction transferring a stake of 3 from U1 to U2 is applied")
+    resultingStakeDistribution1(publicKey2) shouldBe 5
+  }
+
+  "A well-formed transaction" should "preserve the total stake across stake distributions" in new TestSetup {
+    val resultingStakeDistributionTotalStake = resultingStakeDistribution1.values.sum
     resultingStakeDistributionTotalStake shouldBe 20
+  }
+
+  "A \"self\" transaction" should "not modify a stake distributions" in new TestSetup {
+    resultingStakeDistribution2 shouldEqual stakeDistribution
   }
 }


### PR DESCRIPTION
The intention of this PR is to fix the issue with "self" transactions: When a transaction having the same stakeholder as source and recipient is applied, the resulting stake is incorrect.